### PR TITLE
Release dev → master: NCIATWP-9363 Section 508 fixes (+ dev updates)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,7 +114,7 @@ jobs:
             ${{ env.BACKEND_IMAGE_LATEST }}
           cache-from: type=registry,ref=${{ env.BACKEND_IMAGE_LATEST }}
           cache-to: type=inline
-
+    
       - name: Build and push frontend image
         uses: docker/build-push-action@v6.18.0
         with:
@@ -124,7 +124,7 @@ jobs:
           push: true
           build-args: |
             APPLICATION_PATH=${{ env.APPLICATION_PATH }}
-            REACT_APP_VERSION=${{  github.ref_name }}
+            REACT_APP_VERSION="gwasExplorer2.2.2_20260306"
           
           tags: |
             ${{ env.FRONTEND_IMAGE }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,7 +115,6 @@ jobs:
           cache-from: type=registry,ref=${{ env.BACKEND_IMAGE_LATEST }}
           cache-to: type=inline
       
-
       - name: Build and push frontend image
         uses: docker/build-push-action@v6.18.0
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,7 +125,7 @@ jobs:
           push: true
           build-args: |
             APPLICATION_PATH=${{ env.APPLICATION_PATH }}
-            REACT_APP_VERSION=${{  github.ref_name }}
+            REACT_APP_VERSION=${{  github.ref_name }} || "2.2.3_20260312"
           
           tags: |
             ${{ env.FRONTEND_IMAGE }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,7 +114,8 @@ jobs:
             ${{ env.BACKEND_IMAGE_LATEST }}
           cache-from: type=registry,ref=${{ env.BACKEND_IMAGE_LATEST }}
           cache-to: type=inline
-    
+      
+
       - name: Build and push frontend image
         uses: docker/build-push-action@v6.18.0
         with:
@@ -124,7 +125,7 @@ jobs:
           push: true
           build-args: |
             APPLICATION_PATH=${{ env.APPLICATION_PATH }}
-            REACT_APP_VERSION="gwasExplorer2.2.2_20260310"
+            REACT_APP_VERSION=${{  github.ref_name }}
           
           tags: |
             ${{ env.FRONTEND_IMAGE }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,7 +125,7 @@ jobs:
           push: true
           build-args: |
             APPLICATION_PATH=${{ env.APPLICATION_PATH }}
-            REACT_APP_VERSION=${{  github.ref_name }} || "2.2.3_20260312"
+            REACT_APP_VERSION=${{ contains(fromJson('["dev","qa"]'), github.ref_name) && '2.2.3_20260312' || github.ref_name }}
           
           tags: |
             ${{ env.FRONTEND_IMAGE }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   deploy-exploregwas:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     environment: ${{ inputs.tier }}
     env:
@@ -111,8 +112,8 @@ jobs:
           tags: |
             ${{ env.BACKEND_IMAGE }}
             ${{ env.BACKEND_IMAGE_LATEST }}
-          cache-from: type=registry,ref=${{ env.IMAGE_REPOSITORY }}:backend-cache
-          cache-to: type=registry,ref=${{ env.IMAGE_REPOSITORY }}:backend-cache,image-manifest=true,oci-mediatypes=true,mode=max
+          cache-from: type=registry,ref=${{ env.BACKEND_IMAGE_LATEST }}
+          cache-to: type=inline
 
       - name: Build and push frontend image
         uses: docker/build-push-action@v6.18.0
@@ -126,9 +127,9 @@ jobs:
           tags: |
             ${{ env.FRONTEND_IMAGE }}
             ${{ env.FRONTEND_IMAGE_LATEST }}
-          cache-from: type=registry,ref=${{ env.IMAGE_REPOSITORY }}:frontend-cache
-          cache-to: type=registry,ref=${{ env.IMAGE_REPOSITORY }}:frontend-cache,image-manifest=true,oci-mediatypes=true,mode=max
-
+          cache-from: type=registry,ref=${{ env.FRONTEND_IMAGE_LATEST }}
+          cache-to: type=inline
+          
       - name: Debug frontend build artifacts
         run: |
           echo "Application path: ${{ env.APPLICATION_PATH }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
       ECS_MEMORY_UNITS: ${{ secrets.ECS_MEMORY_UNITS || '4096' }}
       TIER: ${{ inputs.tier }}
       IMAGE_TIER: ${{ contains(fromJson('["dev","qa"]'), inputs.tier) && 'development' || 'release' }}
-      CICD_ROLE_ARN: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-cicd
+      CICD_ROLE_ARN: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/power-user-github-actions-cicd
 
     steps:
       - uses: "actions/checkout@v6.0.1"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,6 +124,8 @@ jobs:
           push: true
           build-args: |
             APPLICATION_PATH=${{ env.APPLICATION_PATH }}
+            REACT_APP_VERSION=${{  github.ref_name }}
+          
           tags: |
             ${{ env.FRONTEND_IMAGE }}
             ${{ env.FRONTEND_IMAGE_LATEST }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,7 +124,7 @@ jobs:
           push: true
           build-args: |
             APPLICATION_PATH=${{ env.APPLICATION_PATH }}
-            REACT_APP_VERSION=${{ contains(fromJson('["dev","qa"]'), github.ref_name) && '2.2.3_20260312' || github.ref_name }}
+            REACT_APP_VERSION=${{ github.ref_name }}
           
           tags: |
             ${{ env.FRONTEND_IMAGE }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,7 +124,7 @@ jobs:
           push: true
           build-args: |
             APPLICATION_PATH=${{ env.APPLICATION_PATH }}
-            REACT_APP_VERSION="gwasExplorer2.2.2_20260306"
+            REACT_APP_VERSION="gwasExplorer2.2.2_20260310"
           
           tags: |
             ${{ env.FRONTEND_IMAGE }}

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ config*.json
 *-audit.json
 .DS_Store
 *.env
+
+# local server deps (installed for local backend run)
+/server/node_modules/
+/server/package-lock.json

--- a/client/src/components/controls/swagger-ui/swagger-ui.js
+++ b/client/src/components/controls/swagger-ui/swagger-ui.js
@@ -3,14 +3,35 @@ import SwaggerUi, { presets } from 'swagger-ui';
 import 'swagger-ui/dist/swagger-ui.css';
 
 function patchAccessibility(container) {
-    container.querySelectorAll('.curl-command .copy-to-clipboard button').forEach(btn => {
+    container.querySelectorAll('.copy-to-clipboard button').forEach(btn => {
         if (!btn.getAttribute('aria-label')) {
             btn.setAttribute('aria-label', 'Copy to clipboard');
+        }
+        if (!btn.getAttribute('title')) {
+            btn.setAttribute('title', 'Copy to clipboard');
         }
     });
     container.querySelectorAll('textarea.body-param__text').forEach(textarea => {
         if (!textarea.getAttribute('aria-label')) {
             textarea.setAttribute('aria-label', 'Request body');
+        }
+    });
+    container.querySelectorAll('.parameters-col_description select').forEach(select => {
+        const row = select.closest('tr');
+        const paramName = row?.getAttribute('data-param-name');
+        const visibleName = row?.querySelector('.parameters-col_name .parameter__name')?.textContent?.trim();
+        const labelSource = visibleName || paramName || 'parameter';
+        const readableName = labelSource
+            .replace(/^_+/, '')
+            .replace(/[_-]+/g, ' ')
+            .trim();
+        const label = `Parameter ${readableName || 'value'}`;
+
+        if (!select.getAttribute('aria-label')) {
+            select.setAttribute('aria-label', label);
+        }
+        if (!select.getAttribute('title')) {
+            select.setAttribute('title', label);
         }
     });
 }
@@ -25,6 +46,7 @@ export const SwaggerUI = ({spec}) => {
         });
 
         const container = document.getElementById('swaggerContainer');
+        patchAccessibility(container);
         const observer = new MutationObserver(() => patchAccessibility(container));
         observer.observe(container, { childList: true, subtree: true });
         return () => observer.disconnect();

--- a/client/src/components/controls/swagger-ui/swagger-ui.js
+++ b/client/src/components/controls/swagger-ui/swagger-ui.js
@@ -2,17 +2,77 @@ import React, { useEffect } from 'react';
 import SwaggerUi, { presets } from 'swagger-ui';
 import 'swagger-ui/dist/swagger-ui.css';
 
-export const SwaggerUI = ({spec}) => {
+// Swagger UI generates its own DOM, which ships with several Section 508 / WCAG
+// gaps: parameter <select> elements without an accessible name, occasional
+// icon-only buttons without discernible text, and scrollable code/example
+// blocks that cannot receive keyboard focus. patchAccessibility() repairs these
+// after Swagger renders (and again whenever it re-renders, e.g. when an
+// operation is expanded or "Try it out" is toggled).
+function patchAccessibility(root) {
+    if (!root) return;
 
+    // Give every <select> an accessible name, derived from its parameter name.
+    root.querySelectorAll('select:not([aria-label])').forEach((select) => {
+        const row = select.closest('tr');
+        const paramName = row && row.querySelector('.parameter__name');
+        const label =
+            (paramName && paramName.textContent.replace('*', '').trim()) ||
+            'Select a value';
+        select.setAttribute('aria-label', label);
+    });
+
+    // Ensure icon-only buttons expose discernible text.
+    root.querySelectorAll('button:not([aria-label])').forEach((btn) => {
+        if (btn.textContent.trim() || btn.getAttribute('title')) return;
+        const cls = btn.className || '';
+        let label = 'Button';
+        if (cls.includes('expand-operation')) label = 'Expand operation';
+        else if (cls.includes('authorize')) label = 'Authorize';
+        else if (cls.includes('copy')) label = 'Copy to clipboard';
+        else if (cls.includes('model-toggle')) label = 'Toggle model example';
+        btn.setAttribute('aria-label', label);
+    });
+
+    // Make scrollable code / example blocks keyboard accessible.
+    root.querySelectorAll('.highlight-code, .microlight, pre').forEach((el) => {
+        if (el.hasAttribute('tabindex')) return;
+        el.setAttribute('tabindex', '0');
+        el.setAttribute('role', 'region');
+        if (!el.getAttribute('aria-label')) {
+            el.setAttribute('aria-label', 'Code sample');
+        }
+    });
+}
+
+export const SwaggerUI = ({ spec }) => {
     useEffect(() => {
+        const container = document.getElementById('swaggerContainer');
+
         SwaggerUi({
             dom_id: '#swaggerContainer',
             spec: spec,
             presets: [presets.apis],
+            onComplete: () => patchAccessibility(container),
         });
+
+        // Swagger re-renders portions of its DOM on interaction (expanding an
+        // operation surfaces the parameter selects, etc.), so re-apply the
+        // patch on mutations. The patch only adds attributes to elements that
+        // lack them, so it never triggers itself into a loop.
+        let frame;
+        const observer = new MutationObserver(() => {
+            cancelAnimationFrame(frame);
+            frame = requestAnimationFrame(() => patchAccessibility(container));
+        });
+        if (container) {
+            observer.observe(container, { childList: true, subtree: true });
+        }
+
+        return () => {
+            cancelAnimationFrame(frame);
+            observer.disconnect();
+        };
     });
 
-    return (
-        <div id="swaggerContainer" />
-    );
-}
+    return <div id="swaggerContainer" />;
+};

--- a/client/src/components/controls/swagger-ui/swagger-ui.js
+++ b/client/src/components/controls/swagger-ui/swagger-ui.js
@@ -2,6 +2,19 @@ import React, { useEffect } from 'react';
 import SwaggerUi, { presets } from 'swagger-ui';
 import 'swagger-ui/dist/swagger-ui.css';
 
+function patchAccessibility(container) {
+    container.querySelectorAll('.curl-command .copy-to-clipboard button').forEach(btn => {
+        if (!btn.getAttribute('aria-label')) {
+            btn.setAttribute('aria-label', 'Copy to clipboard');
+        }
+    });
+    container.querySelectorAll('textarea.body-param__text').forEach(textarea => {
+        if (!textarea.getAttribute('aria-label')) {
+            textarea.setAttribute('aria-label', 'Request body');
+        }
+    });
+}
+
 export const SwaggerUI = ({spec}) => {
 
     useEffect(() => {
@@ -10,6 +23,11 @@ export const SwaggerUI = ({spec}) => {
             spec: spec,
             presets: [presets.apis],
         });
+
+        const container = document.getElementById('swaggerContainer');
+        const observer = new MutationObserver(() => patchAccessibility(container));
+        observer.observe(container, { childList: true, subtree: true });
+        return () => observer.disconnect();
     });
 
     return (

--- a/client/src/components/pages/api-access/api-access.js
+++ b/client/src/components/pages/api-access/api-access.js
@@ -603,16 +603,16 @@ export function ApiAccess() {
                 get: {
                     tags: ['metadata'],
                     summary: 'Retrieves metadata about each phenotype specified',
-                    description: `Retrieves metadata about each phenotype specified. The following properties are returned:
-                    <ul>
-                        <li>name - Internal name of the phenotype</li>
-                        <li>display_name - Displayed name</li>
-                        <li>sex - all, female, or male - sex for metadata entry</li>
-                        <li>ancestry - african_american, east_asian, european, TBD - ancestry for metadata entry</li>
-                        <li>chromosome - all, or numeric value - chromosome for metadata entry</li>
-                        <li>lambda_gc - Numeric value of lambda gc</li>
-                        <li>count - Number of variants in chromosome (or 'all' chromosomes)</li>
-                    </ul>`,
+                    description: `Retrieves metadata about each phenotype specified. The following properties are returned:` +
+                        `<ul>` +
+                        `<li>name - Internal name of the phenotype</li>` +
+                        `<li>display_name - Displayed name</li>` +
+                        `<li>sex - all, female, or male - sex for metadata entry</li>` +
+                        `<li>ancestry - african_american, east_asian, european, TBD - ancestry for metadata entry</li>` +
+                        `<li>chromosome - all, or numeric value - chromosome for metadata entry</li>` +
+                        `<li>lambda_gc - Numeric value of lambda gc</li>` +
+                        `<li>count - Number of variants in chromosome (or 'all' chromosomes)</li>` +
+                        `</ul>`,
                     operationId: 'getMetadata',
                     produces: ['application/json'],
                     parameters: [

--- a/client/src/components/pages/api-access/api-access.scss
+++ b/client/src/components/pages/api-access/api-access.scss
@@ -30,7 +30,24 @@
   color: #ff8080 !important;
 }
 
+/* Fix inline-styled comment/link gray values (#888888 on #333333 = 3.56:1, fails 4.5:1) */
+.swagger-ui .highlight-code pre span[style*="color: rgb(136, 136, 136)"],
+.swagger-ui .microlight span[style*="color: rgb(136, 136, 136)"] {
+  color: #b3b3b3 !important;
+}
+
 /* Fix response header lines (#1f2933 on #333333 = 1.16:1, fails 4.5:1) */
 .swagger-ui .headerline {
   color: #ffffff !important;
+}
+
+/* Fix cancel button contrast (#ff6060 on #fcfdff = 2.9:1, fails 4.5:1) */
+.swagger-ui .try-out__btn.cancel {
+  color: #b00020 !important;
+  border-color: #b00020 !important;
+}
+
+/* Fix download contents contrast (#ffffff on #7d8293 = 3.82:1, fails 4.5:1) */
+.swagger-ui .download-contents {
+  color: #000000 !important;
 }

--- a/client/src/components/pages/api-access/api-access.scss
+++ b/client/src/components/pages/api-access/api-access.scss
@@ -1,4 +1,10 @@
-.swagger-ui .opblock.opblock-get .opblock-summary-method {
+.swagger-ui .opblock.opblock-get .opblock-summary-method,
+.swagger-ui .opblock.opblock-post .opblock-summary-method,
+.swagger-ui .opblock.opblock-put .opblock-summary-method,
+.swagger-ui .opblock.opblock-delete .opblock-summary-method,
+.swagger-ui .opblock.opblock-patch .opblock-summary-method,
+.swagger-ui .opblock.opblock-head .opblock-summary-method,
+.swagger-ui .opblock.opblock-options .opblock-summary-method {
   color: #000000 !important;
 }
 
@@ -10,4 +16,21 @@
   background-color: #4990e2;
   color: #000000 !important;
   border-color: #4990e2;
+}
+
+.swagger-ui .microlight .hljs-attr,
+.swagger-ui .highlight-code pre .hljs-attr {
+  color: #f8c555 !important;
+}
+
+/* Fix inline-styled number values (#d36363 on #333333 = 3.45:1, fails 4.5:1) */
+.swagger-ui .highlight-code pre span[style*="color: rgb(211, 99, 99)"],
+.swagger-ui .microlight span[style*="color: rgb(211, 99, 99)"],
+.swagger-ui .body-param__example span[style*="color: rgb(211, 99, 99)"] {
+  color: #ff8080 !important;
+}
+
+/* Fix response header lines (#1f2933 on #333333 = 1.16:1, fails 4.5:1) */
+.swagger-ui .headerline {
+  color: #ffffff !important;
 }

--- a/client/src/components/pages/api-access/api-access.scss
+++ b/client/src/components/pages/api-access/api-access.scss
@@ -11,3 +11,46 @@
   color: #000000 !important;
   border-color: #4990e2;
 }
+
+/* Section 508 color-contrast fixes for Swagger UI's default palette.
+   Swagger ships several text colors that fall below the WCAG AA 4.5:1
+   threshold against their (near-white) backgrounds. Darken them so the
+   API Access documentation meets contrast requirements. */
+
+/* "Cancel" button text/border (#ff6060 -> ~2.9:1) */
+.swagger-ui .btn.cancel {
+  color: #b32424 !important;
+  border-color: #b32424 !important;
+}
+
+/* Light-gray secondary text used throughout operations, parameters,
+   responses, models and tabs */
+.swagger-ui .parameter__type,
+.swagger-ui .parameter__deprecated,
+.swagger-ui .parameter__in,
+.swagger-ui .parameter__extension,
+.swagger-ui .prop-format,
+.swagger-ui .response-col_links,
+.swagger-ui .opblock-summary-path__deprecated,
+.swagger-ui .model .property.primitive,
+.swagger-ui .model-title__text,
+.swagger-ui .tab li,
+.swagger-ui .opblock .opblock-section-header label,
+.swagger-ui .opblock-description-wrapper,
+.swagger-ui .markdown p,
+.swagger-ui .renderedMarkdown p,
+.swagger-ui table.headers .header-example,
+.swagger-ui .info .base-url {
+  color: #454545 !important;
+}
+
+/* Placeholder text in "Try it out" inputs (#999 -> below AA) */
+.swagger-ui input::placeholder,
+.swagger-ui textarea::placeholder {
+  color: #595959 !important;
+}
+
+/* Property type accents in the model viewer (#55a / teal are low-contrast) */
+.swagger-ui .prop-type {
+  color: #3b4151 !important;
+}

--- a/client/src/components/pages/home/home.js
+++ b/client/src/components/pages/home/home.js
@@ -129,22 +129,17 @@ export function Home({ links }) {
                       style={{ width: "100%" }}
                     >
                       <Button
-                        className="my-2 border border-0 font-weight-bold"
+                        as={Link}
+                        to={route}
+                        className="my-2 border border-0 font-weight-bold text-dark stretched-link"
                         style={{
                           backgroundColor: "#2CC799",
                           // borderRadius: '10px',
                           width: "90%",
+                          textDecoration: "none",
                         }}
                       >
-                        <Link
-                          className="stretched-link text-dark"
-                          style={{ textDecoration: "none" }}
-                          exact={exact}
-                          key={index}
-                          to={route}
-                        >
-                          {action}
-                        </Link>
+                        {action}
                       </Button>
                     </Card.Footer>
                   </Card>

--- a/client/src/components/pages/home/home.js
+++ b/client/src/components/pages/home/home.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import Card from "react-bootstrap/Card";
-import { CardDeck, Button } from "react-bootstrap";
+import { CardDeck } from "react-bootstrap";
 import "./home.scss";
 
 export function Home({ links }) {
@@ -128,24 +128,19 @@ export function Home({ links }) {
                       className="bg-white border-top-0"
                       style={{ width: "100%" }}
                     >
-                      <Button
-                        className="my-2 border border-0 font-weight-bold"
+                      <Link
+                        className="my-2 border border-0 font-weight-bold btn btn-primary text-dark"
                         style={{
                           backgroundColor: "#2CC799",
-                          // borderRadius: '10px',
                           width: "90%",
+                          textDecoration: "none",
                         }}
+                        exact={exact}
+                        key={index}
+                        to={route}
                       >
-                        <Link
-                          className="stretched-link text-dark"
-                          style={{ textDecoration: "none" }}
-                          exact={exact}
-                          key={index}
-                          to={route}
-                        >
-                          {action}
-                        </Link>
-                      </Button>
+                        {action}
+                      </Link>
                     </Card.Footer>
                   </Card>
                   <div className="d-lg-none w-100"></div>

--- a/local/.gitignore
+++ b/local/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/local/.gitignore
+++ b/local/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 package-lock.json
 db-init/02-seed-phenotype.sql
+db-init/03-participant-seed.sql

--- a/local/.gitignore
+++ b/local/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 package-lock.json
+db-init/02-seed-phenotype.sql

--- a/local/README.md
+++ b/local/README.md
@@ -1,0 +1,44 @@
+# Local run & 508 accessibility verification (NCIATWP-9363)
+
+The two pages fixed for this ticket — **Home** and **API Access** — are entirely
+client-side, so you only need the React client running to see the fixes. (The
+full backend additionally requires MySQL + Redis; it is not needed for these
+pages.)
+
+## Run the client
+
+```bash
+cd client
+npm install          # first time only
+npm start            # serves http://localhost:3000  (hash-routed)
+```
+
+- Home:       <http://localhost:3000/#/>
+- API Access: <http://localhost:3000/#/api-access>
+
+## Run the accessibility audit
+
+With the client running, in this folder:
+
+```bash
+npm install          # first time only (puppeteer-core + axe-core)
+npm run audit
+```
+
+It launches headless Chrome/Edge, injects **axe-core** (the same engine the NCI
+508 report uses), expands every Swagger operation + "Try it out", and prints
+WCAG 2.0/2.1 A & AA violations for both pages. Expected result after the fixes:
+`PASS: 0 WCAG A/AA violations`.
+
+Override the browser with `CHROME=/path/to/browser npm run audit`.
+
+## What was fixed and how to see it
+
+| Ticket finding | Where | How to verify by hand |
+| --- | --- | --- |
+| **Interactive controls must not be nested** (Home, 3) | `client/src/components/pages/home/home.js` | Each card's action button is now a single link styled as a button (`<a class="btn">`), not a `<button>` wrapping a `<a>`. Inspect a card footer in DevTools. |
+| **select element has an accessible name** (API Access) | `client/src/components/controls/swagger-ui/swagger-ui.js` | Expand an operation → Try it out. Every parameter dropdown now has an `aria-label` (its parameter name). |
+| **Buttons must have discernible text** (API Access) | same wrapper | Any icon-only Swagger button gets an `aria-label`. |
+| **Scrollable region must have keyboard access** (API Access) | same wrapper | Code/example blocks (`.highlight-code`, `.microlight`, `pre`) are now `tabindex="0"` + `role="region"`, so they're reachable and scrollable with the keyboard. |
+| **Lists must be structured correctly** (API Access) | `client/src/components/pages/api-access/api-access.js` | The `/api/metadata` description list no longer renders stray `<br>` elements as direct `<ul>` children. |
+| **Color contrast** (API Access) | `client/src/components/pages/api-access/api-access.scss` | Swagger's low-contrast text (notably the red **Cancel** button) is darkened to meet AA 4.5:1. |

--- a/local/README.md
+++ b/local/README.md
@@ -5,6 +5,40 @@ client-side, so you only need the React client running to see the fixes. (The
 full backend additionally requires MySQL + Redis; it is not needed for these
 pages.)
 
+## Running the data-backed pages (Phenotypes, etc.)
+
+The Home and API Access pages are client-only. The other pages (Phenotypes,
+GWAS, Downloads) call a backend API on `:9000`. With no backend running, those
+calls fail and the browser shows a 500 (e.g. `/web/phenotypes`).
+
+**Data source facts:** the app reads all data from **MySQL** — there is no S3
+access at runtime (the only S3 usage in the repo is HPC backup scripts under
+`database/import/hpc/`). In production the MySQL host is **AWS RDS**; locally we
+point the API at a Docker MySQL. The API also gates `/web/*` routes to browser
+user-agents, so `curl` must send a browser `User-Agent` to test them.
+
+### Start the backend (MySQL + Redis + API)
+
+```bash
+./local/backend.sh        # Docker MySQL+Redis, seed phenotypes, run API (Node 22)
+```
+
+This brings up MySQL + Redis (Docker), seeds the `phenotype` tree from
+`database/import/phenotype.csv`, and runs the Fastify API with host Node.
+`./local/backend.sh down` stops the containers; `reset` also deletes the DB
+volume.
+
+> The repo's `docker/backend.dockerfile` (amazonlinux) can't build behind a
+> TLS-intercepting corporate proxy, so the API is run with host Node here rather
+> than containerized. Node 22 is recommended (Fastify 3 emits deprecation
+> warnings but runs).
+
+**Scope of the local seed:** only the phenotype *tree* is seeded, which fixes
+the `/web/phenotypes` 500 and loads the Phenotype Characteristics page cleanly.
+Selecting a phenotype triggers calls for GWAS variant data / participant
+characteristics, which require the large production dataset and are **not**
+seeded locally.
+
 ## Run the client
 
 ```bash

--- a/local/README.md
+++ b/local/README.md
@@ -33,11 +33,15 @@ volume.
 > than containerized. Node 22 is recommended (Fastify 3 emits deprecation
 > warnings but runs).
 
-**Scope of the local seed:** only the phenotype *tree* is seeded, which fixes
-the `/web/phenotypes` 500 and loads the Phenotype Characteristics page cleanly.
-Selecting a phenotype triggers calls for GWAS variant data / participant
-characteristics, which require the large production dataset and are **not**
-seeded locally.
+**Scope of the local seed:**
+- `gen-seed.py` seeds the phenotype **tree** (visible + searchable).
+- `gen-participant-seed.py` seeds **synthetic participant data** (200
+  participants + `phenotype_metadata`) so the **Phenotype Characteristics**
+  charts render (Frequency All/Age/Sex/Race) for any leaf phenotype. Leaf
+  phenotypes are forced to `binary` for the chart path; the values are random
+  synthetic data, not real PLCO results.
+- The **GWAS Results** pages (Manhattan/QQ/summary/variant lookup) read the
+  large production variant dataset and are **not** seeded locally.
 
 ## Run the client
 

--- a/local/a11y-audit.mjs
+++ b/local/a11y-audit.mjs
@@ -1,0 +1,75 @@
+// Section 508 / WCAG 2.0 & 2.1 A/AA audit for the GWAS Explorer pages covered
+// by NCIATWP-9363 (Home and API Access). Uses axe-core -- the same engine the
+// NCI 508 report is generated with -- driven against the running client via a
+// locally installed Chrome/Edge.
+//
+// Prereqs:  client running (see local/README.md), then in this folder:
+//           npm install && npm run audit
+// Override browser with CHROME=/path/to/browser, base URL with BASE=...
+
+import { existsSync } from "fs";
+import puppeteer from "puppeteer-core";
+import axe from "axe-core";
+
+const BASE = process.env.BASE || "http://localhost:3000";
+const CANDIDATES = [
+  process.env.CHROME,
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+  "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+  "/usr/bin/google-chrome",
+  "/usr/bin/chromium-browser",
+].filter(Boolean);
+const executablePath = CANDIDATES.find((p) => existsSync(p));
+if (!executablePath) {
+  console.error("No Chrome/Edge found. Set CHROME=/path/to/browser.");
+  process.exit(1);
+}
+
+const TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"];
+const browser = await puppeteer.launch({ executablePath, headless: "new", args: ["--no-sandbox", "--disable-gpu"] });
+let total = 0;
+
+async function runAxe(page) {
+  await page.evaluate(axe.source);
+  return page.evaluate(async (tags) => window.axe.run(document, { runOnly: { type: "tag", values: tags } }), TAGS);
+}
+
+function report(name, r) {
+  console.log(`\n===== ${name} =====`);
+  console.log(`Violations: ${r.violations.length}`);
+  total += r.violations.length;
+  for (const v of r.violations.sort((a, b) => b.nodes.length - a.nodes.length)) {
+    console.log(`  [${v.impact}] ${v.id}: ${v.help} (${v.nodes.length})`);
+    v.nodes.slice(0, 5).forEach((n) => console.log(`     - ${n.target.join(" ").slice(0, 80)}`));
+  }
+}
+
+// Home
+{
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1280, height: 1000 });
+  await page.goto(`${BASE}/#/`, { waitUntil: "networkidle2", timeout: 90000 }).catch(() => {});
+  await new Promise((r) => setTimeout(r, 4000));
+  report("Home", await runAxe(page));
+  await page.close();
+}
+
+// API Access -- expand every operation and open "Try it out" so the parameter
+// selects, code samples and action buttons are all present for the audit.
+{
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1280, height: 1000 });
+  await page.goto(`${BASE}/#/api-access`, { waitUntil: "networkidle2", timeout: 90000 }).catch(() => {});
+  await new Promise((r) => setTimeout(r, 4000));
+  await page.evaluate(() => document.querySelectorAll(".swagger-ui .opblock-summary-control,.swagger-ui .opblock-summary").forEach((x) => x.click()));
+  await new Promise((r) => setTimeout(r, 1200));
+  await page.evaluate(() => document.querySelectorAll(".swagger-ui .try-out__btn").forEach((x) => x.click()));
+  await new Promise((r) => setTimeout(r, 1500));
+  report("API Access (expanded + Try it out)", await runAxe(page));
+  await page.close();
+}
+
+await browser.close();
+console.log(`\n=========================================`);
+console.log(total === 0 ? "PASS: 0 WCAG A/AA violations." : `FAIL: ${total} violations.`);
+process.exit(total === 0 ? 0 : 1);

--- a/local/backend.sh
+++ b/local/backend.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Stand up the local GWAS Explorer backend so the data-backed pages work:
+#   - MySQL + Redis in Docker (local/docker-compose.yml)
+#   - phenotype tree seeded from database/import/phenotype.csv
+#   - the Fastify API run with host Node (Node 22 recommended)
+#
+#   ./local/backend.sh          # start datastores, seed, run the API (foreground)
+#   ./local/backend.sh down     # stop the datastore containers (keep data)
+#   ./local/backend.sh reset    # stop and delete the MySQL volume
+#
+# Requires Docker Desktop running. The API streams logs in the foreground;
+# Ctrl-C stops it (the containers keep running -- use `down` to stop them).
+set -euo pipefail
+cd "$(dirname "$0")"
+ROOT="$(cd .. && pwd)"
+
+COMPOSE="docker compose -f docker-compose.yml"
+DB="$COMPOSE exec -T db mysql -uroot -pplcolocal"
+
+case "${1:-up}" in
+  down)  $COMPOSE down; exit 0 ;;
+  reset) $COMPOSE down -v; exit 0 ;;
+esac
+
+if ! docker info >/dev/null 2>&1; then
+  echo "ERROR: Docker daemon is not running. Start Docker Desktop and retry." >&2
+  exit 1
+fi
+
+echo "==> generating phenotype seed from database/import/phenotype.csv"
+python3 gen-seed.py
+
+echo "==> starting MySQL + Redis"
+$COMPOSE up -d
+
+echo "==> waiting for MySQL to be healthy"
+until [ "$(docker inspect -f '{{.State.Health.Status}}' plco-local-db-1 2>/dev/null)" = "healthy" ]; do
+  sleep 2
+done
+
+echo "==> applying schema + seed"
+$DB < db-init/01-schema.sql
+$DB plcogwas < db-init/02-seed-phenotype.sql
+echo "    phenotype rows: $($DB -N -e 'SELECT COUNT(*) FROM plcogwas.phenotype;')"
+
+echo "==> installing server dependencies (first run only)"
+[ -d "$ROOT/server/node_modules" ] || ( cd "$ROOT/server" && npm install )
+
+echo "==> starting Fastify API on http://localhost:9000 (Ctrl-C to stop)"
+echo "    then run the client in another terminal:  (cd client && npm start)"
+echo "    and open http://localhost:3000/#/phenotypes"
+# shellcheck disable=SC1091
+source ./backend.env
+cd "$ROOT/server"
+exec node server.js

--- a/local/backend.sh
+++ b/local/backend.sh
@@ -27,8 +27,9 @@ if ! docker info >/dev/null 2>&1; then
   exit 1
 fi
 
-echo "==> generating phenotype seed from database/import/phenotype.csv"
+echo "==> generating phenotype + participant seeds from database/import/phenotype.csv"
 python3 gen-seed.py
+python3 gen-participant-seed.py
 
 echo "==> starting MySQL + Redis"
 $COMPOSE up -d
@@ -38,10 +39,12 @@ until [ "$(docker inspect -f '{{.State.Health.Status}}' plco-local-db-1 2>/dev/n
   sleep 2
 done
 
-echo "==> applying schema + seed"
+echo "==> applying schema + seeds"
 $DB < db-init/01-schema.sql
 $DB plcogwas < db-init/02-seed-phenotype.sql
-echo "    phenotype rows: $($DB -N -e 'SELECT COUNT(*) FROM plcogwas.phenotype;')"
+$DB plcogwas < db-init/03-participant-seed.sql
+echo "    phenotype rows:        $($DB -N -e 'SELECT COUNT(*) FROM plcogwas.phenotype;')"
+echo "    participant_data rows: $($DB -N -e 'SELECT COUNT(*) FROM plcogwas.participant_data;')"
 
 echo "==> installing server dependencies (first run only)"
 [ -d "$ROOT/server/node_modules" ] || ( cd "$ROOT/server" && npm install )

--- a/local/db-init/01-schema.sql
+++ b/local/db-init/01-schema.sql
@@ -57,3 +57,32 @@ CREATE TABLE IF NOT EXISTS `phenotype_metadata` (
   `participant_count_case` BIGINT,
   `participant_count_control` BIGINT
 );
+
+-- Participant tables backing the Phenotype Characteristics charts
+-- (getPhenotypeParticipants). Seeded with synthetic data by
+-- local/gen-participant-seed.py.
+
+CREATE TABLE IF NOT EXISTS `participant` (
+  `id` INTEGER PRIMARY KEY NOT NULL,
+  `plco_id` VARCHAR(20),
+  `sex` ENUM('female', 'male'),
+  `ancestry` ENUM('white', 'black', 'hispanic', 'asian', 'pacific_islander', 'american_indian'),
+  `genetic_ancestry` VARCHAR(100)
+);
+
+CREATE TABLE IF NOT EXISTS `participant_data` (
+  `id` BIGINT PRIMARY KEY NOT NULL AUTO_INCREMENT,
+  `phenotype_id` INTEGER NOT NULL,
+  `participant_id` INTEGER,
+  `value` DOUBLE,
+  `age` INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS `participant_data_category` (
+  `id` INTEGER PRIMARY KEY NOT NULL AUTO_INCREMENT,
+  `phenotype_id` INTEGER NOT NULL,
+  `value` DOUBLE,
+  `label` TEXT,
+  `show_distribution` BOOLEAN,
+  `order` INTEGER
+);

--- a/local/db-init/01-schema.sql
+++ b/local/db-init/01-schema.sql
@@ -1,0 +1,59 @@
+-- Minimal schema needed for the GWAS Explorer "Phenotype Characteristics"
+-- phenotype tree to load locally. This is a trimmed subset of the production
+-- PLCO schema (database/schema/tables/main.sql) -- just the `phenotype` table
+-- and the `v_phenotype` view that server getPhenotypes() reads from.
+--
+-- The self-referential FK on parent_id is intentionally omitted so the seed
+-- can be inserted in any order.
+
+CREATE DATABASE IF NOT EXISTS plcogwas;
+USE plcogwas;
+
+CREATE TABLE IF NOT EXISTS `phenotype` (
+  `id` INTEGER PRIMARY KEY NOT NULL,
+  `parent_id` INTEGER NULL,
+  `name` VARCHAR(200),
+  `age_name` VARCHAR(200),
+  `display_name` VARCHAR(200),
+  `description` MEDIUMTEXT,
+  `color` VARCHAR(40),
+  `type` ENUM('binary', 'categorical', 'continuous') NULL,
+  `sex_specific` ENUM('female', 'male') NULL,
+  `participant_count` BIGINT,
+  `import_count` BIGINT,
+  `import_date` DATETIME
+);
+
+-- getPhenotypes() selects from v_phenotype and expects a `link` column.
+-- In production this comes from a study join; locally we expose it as NULL.
+CREATE OR REPLACE VIEW `v_phenotype` AS
+  SELECT p.*, NULL AS `link` FROM `phenotype` p;
+
+-- Additional tables queried on the Phenotypes page load (getRanges,
+-- getMetadata). Created empty so those endpoints return [] (200) instead of
+-- 500; foreign keys to lookup tables are omitted for the local subset.
+
+CREATE TABLE IF NOT EXISTS `chromosome_range` (
+  `id` INTEGER PRIMARY KEY NOT NULL AUTO_INCREMENT,
+  `chromosome` VARCHAR(2) NOT NULL,
+  `position_min` BIGINT NOT NULL,
+  `position_max` BIGINT NOT NULL,
+  `position_abs_min` BIGINT NOT NULL,
+  `position_abs_max` BIGINT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS `phenotype_metadata` (
+  `id` INTEGER PRIMARY KEY NOT NULL AUTO_INCREMENT,
+  `phenotype_id` INTEGER,
+  `sex` VARCHAR(20),
+  `ancestry` VARCHAR(40),
+  `chromosome` VARCHAR(4) NOT NULL DEFAULT 'all',
+  `lambda_gc` DOUBLE,
+  `lambda_gc_ld_score` DOUBLE,
+  `average_value` DOUBLE,
+  `standard_deviation` DOUBLE,
+  `count` BIGINT,
+  `participant_count` BIGINT,
+  `participant_count_case` BIGINT,
+  `participant_count_control` BIGINT
+);

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -1,0 +1,34 @@
+# Local datastores for GWAS Explorer: MySQL (seeded with the phenotype tree)
+# and Redis. The Fastify API is run with host Node by local/backend.sh -- the
+# repo's amazonlinux backend image cannot build behind TLS-intercepting
+# corporate proxies (the package mirror presents a self-signed cert), so we
+# don't containerize the API here.
+#
+# Data source note: the app reads from MySQL only (no S3 at runtime); in
+# production the MySQL host is AWS RDS, here it is this local `db` container.
+
+name: plco-local
+
+services:
+  db:
+    image: mysql:8
+    environment:
+      MYSQL_ROOT_PASSWORD: plcolocal
+      MYSQL_DATABASE: plcogwas
+    ports:
+      - "3306:3306"
+    volumes:
+      - plco-db:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-uroot", "-pplcolocal"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+
+volumes:
+  plco-db:

--- a/local/gen-participant-seed.py
+++ b/local/gen-participant-seed.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Generate local/db-init/03-participant-seed.sql: synthetic participant data so
+the GWAS Explorer "Phenotype Characteristics" charts render locally.
+
+For each associatable (leaf) phenotype it seeds:
+  - a phenotype_metadata row (sex/ancestry/chromosome = 'all')
+  - participant_data rows (case/control value + age) against a shared
+    synthetic participant pool
+
+Leaf phenotypes are forced to type 'binary' (the most reliable chart path);
+this is synthetic local data, not the real PLCO results.
+"""
+import csv
+import os
+import random
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+CSV_PATH = os.path.join(HERE, "..", "database", "import", "phenotype.csv")
+OUT_PATH = os.path.join(HERE, "db-init", "03-participant-seed.sql")
+
+N_PARTICIPANTS = 200
+ANCESTRIES = ["white", "white", "white", "black", "hispanic", "asian",
+              "pacific_islander", "american_indian"]
+random.seed(42)
+
+
+def leaf_ids():
+    ids = []
+    with open(CSV_PATH, encoding="utf-8-sig", newline="") as f:
+        reader = csv.reader(f)
+        next(reader, None)
+        for r in reader:
+            if not r or not r[0].strip():
+                continue
+            assoc = (r[3].strip() if len(r) > 3 else "")
+            if assoc and assoc.upper() != "NULL":   # has an association name => leaf
+                ids.append(int(r[0].strip()))
+    return ids
+
+
+def main():
+    ids = leaf_ids()
+    os.makedirs(os.path.dirname(OUT_PATH), exist_ok=True)
+    with open(OUT_PATH, "w", encoding="utf-8") as out:
+        out.write("USE plcogwas;\n")
+        out.write("SET FOREIGN_KEY_CHECKS=0;\n")
+        out.write("TRUNCATE TABLE participant_data;\n")
+        out.write("TRUNCATE TABLE participant;\n")
+        out.write("TRUNCATE TABLE phenotype_metadata;\n")
+        # Use the binary chart path and ensure an age column name exists.
+        out.write("UPDATE phenotype SET type='binary', "
+                  "age_name=COALESCE(age_name,'age_co') WHERE name IS NOT NULL;\n")
+
+        # participant pool
+        participants = []
+        rows = []
+        for pid in range(1, N_PARTICIPANTS + 1):
+            sex = "female" if random.random() < 0.52 else "male"
+            ancestry = random.choice(ANCESTRIES)
+            participants.append((pid, sex, ancestry))
+            rows.append(f"({pid}, 'PLCO{pid:05d}', '{sex}', '{ancestry}')")
+        out.write("INSERT INTO participant (id, plco_id, sex, ancestry) VALUES\n  "
+                  + ",\n  ".join(rows) + ";\n")
+
+        # per-phenotype metadata + participant_data
+        meta_rows = []
+        data_buf = []
+        data_id = 1
+
+        def flush():
+            nonlocal data_buf
+            if data_buf:
+                out.write("INSERT INTO participant_data (id, phenotype_id, participant_id, value, age) VALUES\n  "
+                          + ",\n  ".join(data_buf) + ";\n")
+                data_buf = []
+
+        for pid in ids:
+            prevalence = 0.2 + (pid % 5) * 0.08
+            cases = 0
+            for (part_id, sex, ancestry) in participants:
+                value = 1 if random.random() < prevalence else 0
+                cases += value
+                age = random.randint(55, 79)
+                data_buf.append(f"({data_id}, {pid}, {part_id}, {value}, {age})")
+                data_id += 1
+                if len(data_buf) >= 500:
+                    flush()
+            controls = N_PARTICIPANTS - cases
+            meta_rows.append(
+                f"({pid}, 'all', 'all', 'all', 1.0, 0.5, 0.5, {N_PARTICIPANTS}, "
+                f"{N_PARTICIPANTS}, {cases}, {controls})"
+            )
+        flush()
+
+        out.write(
+            "INSERT INTO phenotype_metadata "
+            "(phenotype_id, sex, ancestry, chromosome, lambda_gc, average_value, standard_deviation, "
+            "count, participant_count, participant_count_case, participant_count_control) VALUES\n  "
+            + ",\n  ".join(meta_rows) + ";\n"
+        )
+        out.write("SET FOREIGN_KEY_CHECKS=1;\n")
+
+    print(f"Wrote {len(ids)} phenotypes x {N_PARTICIPANTS} participants "
+          f"(~{len(ids) * N_PARTICIPANTS} participant_data rows) to {OUT_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/local/gen-seed.py
+++ b/local/gen-seed.py
@@ -63,12 +63,23 @@ def main():
         out.write("SET FOREIGN_KEY_CHECKS=0;\n")
         out.write("TRUNCATE TABLE phenotype;\n")
         for (pid, parent, name, age_name, display_name, description, ptype, sex) in rows:
+            # The phenotype tree (phenotypes-form.js) only shows nodes that have
+            # an import_date (or a descendant leaf that does), and only allows
+            # selecting nodes with a participant_count. Mark the associatable
+            # (leaf) phenotypes -- those with a real `name` -- as "imported" so
+            # the tree is visible and searchable locally. Parent categories
+            # become visible via their descendants.
+            imported = name is not None
+            import_date = "'2024-01-01 00:00:00'" if imported else "NULL"
+            participant_count = "10000" if imported else "NULL"
+            import_count = "1000000" if imported else "NULL"
             out.write(
                 "INSERT INTO phenotype "
-                "(id, parent_id, name, age_name, display_name, description, type, sex_specific) VALUES "
+                "(id, parent_id, name, age_name, display_name, description, type, sex_specific, "
+                "import_date, participant_count, import_count) VALUES "
                 f"({pid}, {parent if parent is not None else 'NULL'}, "
                 f"{sql(name)}, {sql(age_name)}, {sql(display_name)}, {sql(description)}, "
-                f"{sql(ptype)}, {sql(sex)});\n"
+                f"{sql(ptype)}, {sql(sex)}, {import_date}, {participant_count}, {import_count});\n"
             )
         out.write("SET FOREIGN_KEY_CHECKS=1;\n")
     print(f"Wrote {len(rows)} phenotype rows to {OUT_PATH}")

--- a/local/gen-seed.py
+++ b/local/gen-seed.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Generate local/db-init/02-seed-phenotype.sql from the repo's phenotype seed CSV.
+
+Mirrors the column mapping in database/import/import-phenotype.js:
+  CSV: Phenotype ID, Phenotype Parent ID, Display Name, Association Name,
+       Description (Definition), Phenotype Data Type, Age, Sex Specific
+  ->   id, parent_id, display_name, name, description, type, age_name, sex_specific
+"""
+import csv
+import os
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+CSV_PATH = os.path.join(HERE, "..", "database", "import", "phenotype.csv")
+OUT_PATH = os.path.join(HERE, "db-init", "02-seed-phenotype.sql")
+
+TYPES = {"binary", "categorical", "continuous"}
+SEXES = {"female", "male"}
+
+
+def norm(v):
+    v = (v or "").strip()
+    if v == "" or v.upper() == "NULL":
+        return None
+    return v
+
+
+def sql(v):
+    if v is None:
+        return "NULL"
+    return "'" + str(v).replace("\\", "\\\\").replace("'", "''") + "'"
+
+
+def main():
+    rows = []
+    with open(CSV_PATH, encoding="utf-8-sig", newline="") as f:
+        reader = csv.reader(f)
+        next(reader, None)  # header
+        for r in reader:
+            if not r or not norm(r[0]):
+                continue
+            pid = norm(r[0])
+            parent = norm(r[1]) if len(r) > 1 else None
+            display_name = norm(r[2]) if len(r) > 2 else None
+            name = norm(r[3]) if len(r) > 3 else None
+            description = norm(r[4]) if len(r) > 4 else None
+            ptype = norm(r[5]) if len(r) > 5 else None
+            age_name = norm(r[6]) if len(r) > 6 else None
+            sex = norm(r[7]) if len(r) > 7 else None
+
+            if ptype == "ordinal":
+                ptype = "categorical"
+            if ptype not in TYPES:
+                ptype = None
+            if sex not in SEXES:
+                sex = None
+
+            rows.append((int(pid), int(parent) if parent else None, name,
+                         age_name, display_name, description, ptype, sex))
+
+    os.makedirs(os.path.dirname(OUT_PATH), exist_ok=True)
+    with open(OUT_PATH, "w", encoding="utf-8") as out:
+        out.write("USE plcogwas;\n")
+        out.write("SET FOREIGN_KEY_CHECKS=0;\n")
+        out.write("TRUNCATE TABLE phenotype;\n")
+        for (pid, parent, name, age_name, display_name, description, ptype, sex) in rows:
+            out.write(
+                "INSERT INTO phenotype "
+                "(id, parent_id, name, age_name, display_name, description, type, sex_specific) VALUES "
+                f"({pid}, {parent if parent is not None else 'NULL'}, "
+                f"{sql(name)}, {sql(age_name)}, {sql(display_name)}, {sql(description)}, "
+                f"{sql(ptype)}, {sql(sex)});\n"
+            )
+        out.write("SET FOREIGN_KEY_CHECKS=1;\n")
+    print(f"Wrote {len(rows)} phenotype rows to {OUT_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/local/package.json
+++ b/local/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "plco-atlas-local-a11y",
+  "private": true,
+  "type": "module",
+  "description": "Local Section 508 / WCAG audit tooling for GWAS Explorer (NCIATWP-9363)",
+  "scripts": {
+    "audit": "node a11y-audit.mjs"
+  },
+  "dependencies": {
+    "axe-core": "^4.10.0",
+    "puppeteer-core": "^23.0.0"
+  }
+}

--- a/server/services/query.js
+++ b/server/services/query.js
@@ -335,7 +335,7 @@ async function getVariants({ connection, logger }, params) {
             AND sex = ? 
             AND chromosome = ? 
             AND phenotype_id IN (${phenotypeIdPlaceholders})`,
-    [ancestry, sex, +params.chromosome || "all", ...phenotypeIds]
+    [ancestry, sex, +params.chromosome || "all", phenotypeIds]
   );
   // use only phenotypes with data, skip check if searching by SNP
   if (!params.snp && (!metadata.length || metadata.some((m) => !m.count)))

--- a/server/services/query.js
+++ b/server/services/query.js
@@ -361,10 +361,20 @@ async function getVariants({ connection, logger }, params) {
   if (!params.columns || params.columns.includes("sex"))
     columns.unshift(`"${sex}" as sex`);
   if (!tables.length) {
-    // throw new Error('No data exists for the selected phenotype(s) stratification(s)');
-    console.log("No data exists for the selected phenotype(s)");
-    return { columns: columns, data: [] };
+    const phenotypeNames = phenotypes.map(p => p.name).join(', ');
+    const errorMsg = `No variant data tables found for phenotype(s): ${phenotypeNames} with sex=${sex} and ancestry=${ancestry}. The tables may not exist or the phenotype may not have data for this stratification.`;
+    logger.error(errorMsg);
+    throw new Error(errorMsg);
   }
+  
+  // Log which tables were found vs requested
+  const foundPhenotypes = tables.map(t => t.phenotype_id);
+  const missingPhenotypes = phenotypes.filter(p => !foundPhenotypes.includes(p.id.toString()));
+  if (missingPhenotypes.length > 0) {
+    logger.warn(`Warning: Tables not found for phenotypes: ${missingPhenotypes.map(p => `${p.id}(${p.name})`).join(', ')}`);
+  }
+  logger.debug(`Found ${tables.length} tables for query: ${tables.map(t => t.table_name).join(', ')}`);
+  
   const conditions = [
     coalesce(params.id, `id = :id`),
     coalesce(
@@ -414,9 +424,9 @@ async function getVariants({ connection, logger }, params) {
   const unionQuery = tables
     .map((t) => {
       // add phenotype_id column if needed
-      let queryColumns = columns;
+      let queryColumns = [...columns]; // Create a new array copy
       if (!params.columns || params.columns.includes("phenotype_id"))
-        queryColumns = [`${t.phenotype_id} as phenotype_id`, ...columns];
+        queryColumns = [`${t.phenotype_id} as phenotype_id`, ...queryColumns];
       // generate select statement for current table
       return `(SELECT ${queryColumns.join(",")} FROM ${t.table_name} 
           ${conditions.length ? `WHERE ${conditions}` : ""})`;

--- a/server/services/query.js
+++ b/server/services/query.js
@@ -428,8 +428,8 @@ async function getVariants({ connection, logger }, params) {
       if (!params.columns || params.columns.includes("phenotype_id"))
         queryColumns = [`${t.phenotype_id} as phenotype_id`, ...queryColumns];
       // generate select statement for current table
-      return `(SELECT ${queryColumns.join(",")} FROM ${t.table_name} 
-          ${conditions.length ? `WHERE ${conditions}` : ""})`;
+      return `SELECT ${queryColumns.join(",")} FROM ${t.table_name} 
+          ${conditions.length ? `WHERE ${conditions}` : ""}`;
     })
     .join(" UNION ");
   

--- a/server/services/query.js
+++ b/server/services/query.js
@@ -335,7 +335,7 @@ async function getVariants({ connection, logger }, params) {
             AND sex = ? 
             AND chromosome = ? 
             AND phenotype_id IN (${phenotypeIdPlaceholders})`,
-    [ancestry, sex, +params.chromosome || "all", phenotypeIds]
+    [ancestry, sex, +params.chromosome || "all", ...phenotypeIds]
   );
   // use only phenotypes with data, skip check if searching by SNP
   if (!params.snp && (!metadata.length || metadata.some((m) => !m.count)))

--- a/server/services/query.js
+++ b/server/services/query.js
@@ -411,22 +411,25 @@ async function getVariants({ connection, logger }, params) {
   const limit = Math.min(+params.limit, defaultLimit) || defaultLimit; // set hard limit to prevent overflow
   const offset = +params.offset || 0;
   // generate sql to query variants table(s)
-  const sql =
-    tables
-      .map((t) => {
-        // add phenotype_id column if needed
-        let queryColumns = columns;
-        if (!params.columns || params.columns.includes("phenotype_id"))
-          queryColumns = [`${t.phenotype_id} as phenotype_id`, ...columns];
-        // generate select statement for current table
-        return `SELECT ${queryColumns.join(",")} FROM ${t.table_name} 
-            ${conditions.length ? `WHERE ${conditions}` : ""}`;
-      })
-      .join(" UNION ") +
-    `
+  const unionQuery = tables
+    .map((t) => {
+      // add phenotype_id column if needed
+      let queryColumns = columns;
+      if (!params.columns || params.columns.includes("phenotype_id"))
+        queryColumns = [`${t.phenotype_id} as phenotype_id`, ...columns];
+      // generate select statement for current table
+      return `(SELECT ${queryColumns.join(",")} FROM ${t.table_name} 
+          ${conditions.length ? `WHERE ${conditions}` : ""})`;
+    })
+    .join(" UNION ");
+  
+  const sql = tables.length > 1 
+    ? `SELECT * FROM (${unionQuery}) AS combined
         ${params.orderBy ? `ORDER BY ${orderBy} ${order}` : ""}
-        LIMIT ${offset}, ${limit}
-    `;
+        LIMIT ${offset}, ${limit}`
+    : `${unionQuery}
+        ${params.orderBy ? `ORDER BY ${orderBy} ${order}` : ""}
+        LIMIT ${offset}, ${limit}`;
   logger.debug(`getVariants sql: ${sql}`);
   // query database
   const [data, metaColumns] = await connection.execute(

--- a/server/services/query.js
+++ b/server/services/query.js
@@ -335,7 +335,7 @@ async function getVariants({ connection, logger }, params) {
             AND sex = ? 
             AND chromosome = ? 
             AND phenotype_id IN (${phenotypeIdPlaceholders})`,
-    [ancestry, sex, +params.chromosome || "all", phenotypeIds]
+    [ancestry, sex, +params.chromosome || "all", ...phenotypeIds]
   );
   // use only phenotypes with data, skip check if searching by SNP
   if (!params.snp && (!metadata.length || metadata.some((m) => !m.count)))
@@ -360,12 +360,6 @@ async function getVariants({ connection, logger }, params) {
     columns.unshift(`"${ancestry}" as ancestry`);
   if (!params.columns || params.columns.includes("sex"))
     columns.unshift(`"${sex}" as sex`);
-  if (!tables.length) {
-    const phenotypeNames = phenotypes.map(p => p.name).join(', ');
-    const errorMsg = `No variant data tables found for phenotype(s): ${phenotypeNames} with sex=${sex} and ancestry=${ancestry}. The tables may not exist or the phenotype may not have data for this stratification.`;
-    logger.error(errorMsg);
-    throw new Error(errorMsg);
-  }
   
   // Log which tables were found vs requested
   const foundPhenotypes = tables.map(t => t.phenotype_id);
@@ -373,6 +367,16 @@ async function getVariants({ connection, logger }, params) {
   if (missingPhenotypes.length > 0) {
     logger.warn(`Warning: Tables not found for phenotypes: ${missingPhenotypes.map(p => `${p.id}(${p.name})`).join(', ')}`);
   }
+  
+  // If no tables found, return empty result with proper column structure
+  if (!tables.length) {
+    logger.warn(`No variant data tables found for any requested phenotypes with sex=${sex} and ancestry=${ancestry}`);
+    let resultColumns = [...columns];
+    if (!params.columns || params.columns.includes("phenotype_id"))
+      resultColumns = ["phenotype_id", ...resultColumns];
+    return { data: [], columns: resultColumns };
+  }
+  
   logger.debug(`Found ${tables.length} tables for query: ${tables.map(t => t.table_name).join(', ')}`);
   
   const conditions = [


### PR DESCRIPTION
**Jira ticket: [NCIATWP-9363](https://tracker.nci.nih.gov/browse/NCIATWP-9363)**

## Ticket(s)
- **NCIATWP-9363** — Section 508 accessibility fixes for GWAS Explorer (Home and API Access pages)

## Summary of changes
Promotes `dev` to `master`. The headline change is the **NCIATWP-9363 Section 508 fixes**; the branch also carries dev updates accumulated since the last `master` release.

**508 fixes (NCIATWP-9363)**

*Home* (`client/src/components/pages/home/home.js`)
- *Interactive controls must not be nested* — each card's action was a `<Link>` nested inside a `<Button>`. It now renders as a single link styled as a button (no nested interactive control).

*API Access* (Swagger UI)
- *Select element must have an accessible name* / *Buttons must have discernible text* / *Scrollable region must have keyboard access* (`client/src/components/controls/swagger-ui/swagger-ui.js`) — a post-render patch (re-applied on DOM mutation) labels parameter `<select>`s, copy/icon-only buttons, and request-body textareas, and makes code/example blocks keyboard-focusable (`tabindex="0"`, `role="region"`).
- *Lists must be structured correctly* (`client/src/components/pages/api-access/api-access.js`) — the `/api/metadata` description list no longer emits stray `<br>` as direct `<ul>` children.
- *Color contrast* (`client/src/components/pages/api-access/api-access.scss`) — darkened Swagger's low-contrast text (Cancel/Execute buttons, parameter labels, syntax colors, grays) to meet WCAG AA 4.5:1.

**Other dev updates included in this release**
- `server/services/query.js` — multiple-variant lookup fixes and no-phenotypes error handling.
- `.github/workflows/deploy.yml` — `REACT_APP_VERSION` / `github.ref_name` version handling and CI/CD tweaks.
- `local/` — Dockerized MySQL+Redis standup + seed generators + axe-core audit tooling (developer-only; not shipped to the app).

## Where the reviewer can test
The two fixed pages are client-only:
```bash
cd client && npm install && npm start
```
- Home: `/#/` — card action buttons are single `<a class="btn">` (no `<button><a>`).
- API Access: `/#/api-access` — expand an operation → Try it out; selects have `aria-label`s, code blocks are keyboard-focusable, Cancel/Execute and parameter labels meet contrast, and the `/api/metadata` description renders a clean bullet list.

Automated check with **axe-core** (same engine as the 508 report): **0 WCAG A/AA violations** on Home and API Access.

## Additional notes
- Local dependency versions are newer than the audited deploy, so live violation counts differed from the ticket; the fixes are written defensively to cover each category regardless of Swagger version.
- This PR resolved a conflict where `dev` had an independent 508 implementation — both were combined (no fix dropped) and re-verified at 0 violations.
